### PR TITLE
Prevent duplicate sources-jar deploy during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,20 @@
             </plugin>
         </plugins>
       </pluginManagement>
+      <plugins>
+          <!-- Prevents maven-release-plugin from activating Maven's built-in release-profile
+               during release:perform (performRelease=true), which otherwise binds an extra
+               source:jar-no-fork execution on top of the attach-sources execution already bound
+               via the parent POM's wso2-release profile, causing a duplicate sources-jar deploy
+               that Nexus3 rejects as an immutable-artifact conflict. -->
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-release-plugin</artifactId>
+              <configuration>
+                  <useReleaseProfile>false</useReleaseProfile>
+              </configuration>
+          </plugin>
+      </plugins>
     </build>
 
     <scm>


### PR DESCRIPTION
## Summary
- `maven-release-plugin:2.5.3` defaults `useReleaseProfile` to `true`, which activates Maven's built-in `release-profile` (inherited from the super POM) during `release:perform`.
- This built-in profile binds an extra `maven-source-plugin` execution (`jar-no-fork`) under the same execution id (`attach-sources`) already bound by the parent POM's `wso2-release` profile (goal `jar`), so both goals run and two "sources"-classified artifacts get built and deployed for the same GAV.
- Nexus3 hosted release repositories are immutable, so the second deploy attempt fails with `400 ... cannot be updated`, failing the whole release.
- This sets `useReleaseProfile=false` on `maven-release-plugin` so the built-in profile never activates, leaving only the intended `wso2-release`-bound `attach-sources` execution.

## Test plan
- [ ] Run `release:prepare release:perform` and confirm only one `attach-sources` execution (goal `jar`) runs per module, and the sources jar deploys once successfully.